### PR TITLE
Support build kptools run on windows

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -215,6 +215,56 @@ jobs:
           allowUpdates: true
           replacesArtifacts: true
 
+  Build-kptools-windows:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Check out
+        uses: actions/checkout@v3
+      - name: Install mingw32 cross toolchains
+        run: |
+          MINGW_LLVM_URL="https://github.com/mstorsjo/llvm-mingw/releases/download/20231128/llvm-mingw-20231128-msvcrt-ubuntu-20.04-x86_64.tar.xz"
+          mkdir -p $HOME/mingw-llvm
+          wget $MINGW_LLVM_URL -O $HOME/mingw-llvm/llvm.tar.xz
+          cd $HOME/mingw-llvm
+          tar -xvf llvm.tar.xz --strip-components 1
+
+      - name: Generate version
+        id: parse_version
+        run: |
+          MAJOR=$(grep '#define MAJOR' version | awk '{print $3}')
+          MINOR=$(grep '#define MINOR' version | awk '{print $3}')
+          PATCH=$(grep '#define PATCH' version | awk '{print $3}')
+          VERSION="$MAJOR.$MINOR.$PATCH"
+          echo "Generated Version: $VERSION"
+          echo "VERSION=$VERSION" >> $GITHUB_OUTPUT
+
+      - name: Build kptools
+        run: |
+          export PATH="$HOME/mingw-llvm/bin:$PATH"
+          export ANDROID=1
+
+          ABIS="x86_64 i686 aarch64 armv7"
+          for i in $ABIS; do
+            echo "- Compiling kptools-$i-win.exe"
+            make -C tools CC=$i-w64-mingw32-clang
+            mv tools/kptools.exe kptools-$i-win.exe
+            make -C tools clean
+          done
+
+          7za a kptools-win.zip -tZIP *.exe
+
+      - name: Release
+        uses: ncipollo/release-action@v1.12.0
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          tag: ${{ steps.parse_version.outputs.VERSION }}
+          artifacts: |
+            kptools-win.zip
+          allowUpdates: true
+          replacesArtifacts: true
+
   Build-kptools-mac:
     runs-on: macos-latest
     permissions:

--- a/.github/workflows/build_dev.yml
+++ b/.github/workflows/build_dev.yml
@@ -218,6 +218,56 @@ jobs:
           replacesArtifacts: true
           prerelease: true
 
+  Build-kptools-windows:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Check out
+        uses: actions/checkout@v3
+      - name: Install mingw32 cross toolchains
+        run: |
+          MINGW_LLVM_URL="https://github.com/mstorsjo/llvm-mingw/releases/download/20231128/llvm-mingw-20231128-msvcrt-ubuntu-20.04-x86_64.tar.xz"
+          mkdir -p $HOME/mingw-llvm
+          wget $MINGW_LLVM_URL -O $HOME/mingw-llvm/llvm.tar.xz
+          cd $HOME/mingw-llvm
+          tar -xvf llvm.tar.xz --strip-components 1
+
+      - name: Generate version
+        id: parse_version
+        run: |
+          MAJOR=$(grep '#define MAJOR' version | awk '{print $3}')
+          MINOR=$(grep '#define MINOR' version | awk '{print $3}')
+          PATCH=$(grep '#define PATCH' version | awk '{print $3}')
+          VERSION="$MAJOR.$MINOR.$PATCH"
+          echo "Generated Version: $VERSION"
+          echo "VERSION=$VERSION" >> $GITHUB_OUTPUT
+
+      - name: Build kptools
+        run: |
+          export PATH="$HOME/mingw-llvm/bin:$PATH"
+          export ANDROID=1
+
+          ABIS="x86_64 i686 aarch64 armv7"
+          for i in $ABIS; do
+            echo "- Compiling kptools-$i-win.exe"
+            make -C tools CC=$i-w64-mingw32-clang
+            mv tools/kptools.exe kptools-$i-win.exe
+            make -C tools clean
+          done
+
+          7za a kptools-win.zip -tZIP *.exe
+
+      - name: Release
+        uses: ncipollo/release-action@v1.12.0
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          tag: ${{ steps.parse_version.outputs.VERSION }}
+          artifacts: |
+            kptools-win.zip
+          allowUpdates: true
+          replacesArtifacts: true
+
   Build-kptools-mac:
     runs-on: macos-latest
     permissions:

--- a/tools/Makefile
+++ b/tools/Makefile
@@ -9,11 +9,14 @@ endif
 objs := image.o kallsym.o kptools.o order.o
 
 .PHONY: all
-all: kptools
+all: preset.h kptools
 
 .PHONY: kptools
 kptools: ${objs}
 	${CC} -o $@ $^
+
+preset.h:
+	@cp -f ../kernel/include/$@ $@
 
 %.o : %.c
 	$(CC) -c $(CFLAGS) $(CPPFLAGS) $< -o $@

--- a/tools/kallsym.h
+++ b/tools/kallsym.h
@@ -105,6 +105,27 @@ typedef struct
 
 } kallsym_t;
 
+#ifdef _WIN32
+#include <string.h>
+static void *memmem(const void *haystack, size_t haystack_len, 
+    const void * const needle, const size_t needle_len)
+{
+    if (haystack == NULL) return NULL; // or assert(haystack != NULL);
+    if (haystack_len == 0) return NULL;
+    if (needle == NULL) return NULL; // or assert(needle != NULL);
+    if (needle_len == 0) return NULL;
+    
+    for (const char *h = haystack;
+            haystack_len >= needle_len;
+            ++h, --haystack_len) {
+        if (!memcmp(h, needle, needle_len)) {
+            return (void*)h;
+        }
+    }
+    return NULL;
+}
+#endif
+
 int analyze_kallsym_info(kallsym_t *info, char *img, int32_t imglen, enum arch_type arch, int32_t is_64);
 int dump_all_symbols(kallsym_t *info, char *img);
 int get_symbol_index_offset(kallsym_t *info, char *img, int32_t index);


### PR DESCRIPTION
I've alread build a kptools.exe on windows and test it worked fine on my device(Oneplus 6T lineageos 20.0 android13 kernel 4.9)

![dcc76d21ec93a3ff102e15f6af5f4545](https://github.com/bmax121/KernelPatch/assets/46290091/6d88879d-ef72-4bc9-896e-353ad37ca013)

![83b7ea735f5387e732aa1272f8993142](https://github.com/bmax121/KernelPatch/assets/46290091/47fe541a-2e95-48e1-a6a1-1696a3a72ec8)

magiskboot already have windows build and worked fine yet.
[magiskboot](https://github.com/ookiineko/magiskboot_build)

So we can use windows to patch a kernel.