### PR TITLE
kptools: Support compile kptools for windows target

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -215,6 +215,52 @@ jobs:
           allowUpdates: true
           replacesArtifacts: true
 
+  Build-kptools-windows:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Check out
+        uses: actions/checkout@v3
+      - name: Install mingw32 cross toolchains
+        run: |
+          MINGW_LLVM_URL="https://github.com/mstorsjo/llvm-mingw/releases/download/20231128/llvm-mingw-20231128-msvcrt-ubuntu-20.04-x86_64.tar.xz"
+          mkdir -p $HOME/mingw-llvm
+          wget $MINGW_LLVM_URL -O $HOME/mingw-llvm/llvm.tar.xz
+          cd $HOME/mingw-llvm
+          tar -xvf llvm.tar.xz --strip-components 1
+      - name: Generate version
+        id: parse_version
+        run: |
+          MAJOR=$(grep '#define MAJOR' version | awk '{print $3}')
+          MINOR=$(grep '#define MINOR' version | awk '{print $3}')
+          PATCH=$(grep '#define PATCH' version | awk '{print $3}')
+          VERSION="$MAJOR.$MINOR.$PATCH"
+          echo "Generated Version: $VERSION"
+          echo "VERSION=$VERSION" >> $GITHUB_OUTPUT
+      - name: Build kptools
+        run: |
+          export PATH="$HOME/mingw-llvm/bin:$PATH"
+          export ANDROID=1
+          ABIS="x86_64 i686 aarch64 armv7"
+          for i in $ABIS; do
+            make -C kernel hdr TARGET_COMPILE=placeholder
+            echo "- Compiling kptools-$i-win.exe"
+            make -C tools CC=$i-w64-mingw32-clang
+            mv tools/kptools.exe kptools-$i-win.exe
+            make -C tools clean
+          done
+          7za a kptools-win.zip -tZIP *.exe
+      - name: Release
+        uses: ncipollo/release-action@v1.12.0
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          tag: ${{ steps.parse_version.outputs.VERSION }}
+          artifacts: |
+            kptools-win.zip
+          allowUpdates: true
+          replacesArtifacts: true
+
   Build-kptools-mac:
     runs-on: macos-latest
     permissions:

--- a/tools/kallsym.h
+++ b/tools/kallsym.h
@@ -105,6 +105,27 @@ typedef struct
 
 } kallsym_t;
 
+#ifdef _WIN32
+#include <string.h>
+static void *memmem(const void *haystack, size_t haystack_len, 
+    const void * const needle, const size_t needle_len)
+{
+    if (haystack == NULL) return NULL; // or assert(haystack != NULL);
+    if (haystack_len == 0) return NULL;
+    if (needle == NULL) return NULL; // or assert(needle != NULL);
+    if (needle_len == 0) return NULL;
+
+    for (const char *h = haystack;
+            haystack_len >= needle_len;
+            ++h, --haystack_len) {
+        if (!memcmp(h, needle, needle_len)) {
+            return (void*)h;
+        }
+    }
+    return NULL;
+}
+#endif
+
 int analyze_kallsym_info(kallsym_t *info, char *img, int32_t imglen, enum arch_type arch, int32_t is_64);
 int dump_all_symbols(kallsym_t *info, char *img);
 int get_symbol_index_offset(kallsym_t *info, char *img, int32_t index);


### PR DESCRIPTION
I have tried magiskboot and kptools on windows, and it worked fine to patch my oneplus 6t(lineageos 20.0)