### PR TITLE
kptools: Fix some platform difference on windows

### DIFF
--- a/tools/common.c
+++ b/tools/common.c
@@ -56,7 +56,7 @@ void read_file_align(const char *path, char **con, int *out_len, int align)
 
 void write_file(const char *path, const char *con, int len, bool append)
 {
-    FILE *fout = fopen(path, append ? "a" : "w");
+    FILE *fout = fopen(path, append ? "ab" : "wb");
     if (!fout) tools_error_exit("open %s %s\n", path, strerror(errno));
     int writelen = fwrite(con, 1, len, fout);
     if (writelen != len) tools_error_exit("write file: %s incomplete\n", path);

--- a/tools/fls_ffs.h
+++ b/tools/fls_ffs.h
@@ -40,33 +40,33 @@ static inline int fls(unsigned int x)
     return r;
 }
 
-static inline unsigned long __fls(unsigned long word)
+static inline uint64_t __fls(uint64_t word)
 {
     int num = BITS_PER_LONG - 1;
 
 #if BITS_PER_LONG == 64
-    if (!(word & (~0ul << 32))) {
+    if (!(word & (~0ull << 32))) {
         num -= 32;
         word <<= 32;
     }
 #endif
-    if (!(word & (~0ul << (BITS_PER_LONG - 16)))) {
+    if (!(word & (~0ull << (BITS_PER_LONG - 16)))) {
         num -= 16;
         word <<= 16;
     }
-    if (!(word & (~0ul << (BITS_PER_LONG - 8)))) {
+    if (!(word & (~0ull << (BITS_PER_LONG - 8)))) {
         num -= 8;
         word <<= 8;
     }
-    if (!(word & (~0ul << (BITS_PER_LONG - 4)))) {
+    if (!(word & (~0ull << (BITS_PER_LONG - 4)))) {
         num -= 4;
         word <<= 4;
     }
-    if (!(word & (~0ul << (BITS_PER_LONG - 2)))) {
+    if (!(word & (~0ull << (BITS_PER_LONG - 2)))) {
         num -= 2;
         word <<= 2;
     }
-    if (!(word & (~0ul << (BITS_PER_LONG - 1)))) num -= 1;
+    if (!(word & (~0ull << (BITS_PER_LONG - 1)))) num -= 1;
     return num;
 }
 
@@ -82,7 +82,7 @@ static inline int fls64(u64 x)
  *
  * Undefined if no bit exists, so code should check against 0 first.
  */
-static inline unsigned long __ffs(unsigned long word)
+static inline uint64_t __ffs(uint64_t word)
 {
     int num = 0;
 

--- a/tools/insn.c
+++ b/tools/insn.c
@@ -109,6 +109,17 @@ static inline unsigned long hweight64(u64 w)
 #define GENMASK(h, l) (((~0UL) << (l)) & (~0UL >> (BITS_PER_LONG - 1 - (h))))
 #define GENMASK_ULL(h, l) (((~0ULL) << (l)) & (~0ULL >> (BITS_PER_LONG_LONG - 1 - (h))))
 
+#ifdef _WIN32
+/*
+ * On windows platform 0ul take 4 bytes but linux take 8 bytes
+ * We must use 0ull instead 0ul to ensure no overflow
+ */
+#undef  GENMASK
+#define BITS_PER_LONG_LONG BITS_PER_LONG
+#define GENMASK GENMASK_ULL
+#endif
+
+
 /*
  * #imm16 values used for BRK instruction generation
  * Allowed values for kgbd are 0x400 - 0x7ff


### PR DESCRIPTION
unsigned long on windows is 4 bytes long, but on linux is 8 bytes long, which means shift may overflow on windows.
        
And i found write_file func have an issue cause fopen without `"b"` flag, cause windows and linux have their different impl.

Now the patched kernel is same both linux and windows