### PR TITLE
kernel: fix build errors for clang

### DIFF
--- a/kernel/include/cache.h
+++ b/kernel/include/cache.h
@@ -45,7 +45,7 @@ enum dma_data_direction
 static inline uint32_t current_el(void)
 {
     uint32_t el;
-    asm volatile("mrs %0, CurrentEL" : "=r"(el));
+    asm volatile("mrs %w0, CurrentEL" : "=r"(el));
     return el >> 2;
 }
 

--- a/kernel/linux/include/linux/rcupdate.h
+++ b/kernel/linux/include/linux/rcupdate.h
@@ -78,6 +78,7 @@ static inline void synchronize_rcu(void)
 static inline unsigned long get_completed_synchronize_rcu(void)
 {
     kfunc_call(get_completed_synchronize_rcu)
+    return 0;
 }
 static inline void get_completed_synchronize_rcu_full(struct rcu_gp_oldstate *rgosp)
 {
@@ -136,18 +137,22 @@ static inline void rcu_irq_work_resched(void)
 static inline int rcu_read_lock_held(void)
 {
     kfunc_call(rcu_read_lock_held);
+    return 0;
 }
 static inline int rcu_read_lock_bh_held(void)
 {
     kfunc_call(rcu_read_lock_bh_held);
+    return 0;
 }
 static inline int rcu_read_lock_sched_held(void)
 {
     kfunc_call(rcu_read_lock_sched_held);
+    return 0;
 }
 static inline int rcu_read_lock_any_held(void)
 {
     kfunc_call(rcu_read_lock_any_held);
+    return 0;
 }
 
 static inline void rcu_init_nohz(void)
@@ -157,10 +162,12 @@ static inline void rcu_init_nohz(void)
 static inline int rcu_nocb_cpu_offload(int cpu)
 {
     kfunc_call(rcu_nocb_cpu_offload, cpu);
+    return 0;
 }
 static inline int rcu_nocb_cpu_deoffload(int cpu)
 {
     kfunc_call(rcu_nocb_cpu_deoffload, cpu);
+    return 0;
 }
 static inline void rcu_nocb_flush_deferred_wakeup(void)
 {

--- a/kernel/patch/module/module.c
+++ b/kernel/patch/module/module.c
@@ -175,6 +175,7 @@ static int simplify_symbols(struct module *mod, const struct load_info *info)
     int ret = 0;
 
     for (i = 1; i < symsec->sh_size / sizeof(Elf_Sym); i++) {
+        unsigned long addr;
         const char *name = info->strtab + sym[i].st_name;
         switch (sym[i].st_shndx) {
         case SHN_COMMON:
@@ -186,7 +187,7 @@ static int simplify_symbols(struct module *mod, const struct load_info *info)
         case SHN_ABS:
             break;
         case SHN_UNDEF:
-            unsigned long addr = symbol_lookup_name(name);
+            addr = symbol_lookup_name(name);
             // kernel symbol cause overflow in relocation
             // if (!addr) addr = kallsyms_lookup_name(name);
             if (!addr) {


### PR DESCRIPTION
This PR fixes some compile error for clang when I was trying to cross compile kpimg.
```shell
KernelPatch/kernel/include/cache.h:48:45: error: value size does not match register size specified by the constraint and modifier
    asm volatile("mrs %0, CurrentEL" : "=r"(el));
                                            ^
KernelPatch/kernel/patch/module/module.c:13:10: note: in file included from KernelPatch/kernel/patch/module/module.c:13:
#include <cache.h>
         ^
KernelPatch/kernel/include/cache.h:48:23: note: use constraint modifier "w"
    asm volatile("mrs %0, CurrentEL" : "=r"(el));
                      ^~~
KernelPatch/kernel/linux/include/linux/rcupdate.h:81:1: error: non-void function does not return a value in all control paths
}
^
KernelPatch/kernel/patch/module/module.c:23:10: note: in file included from KernelPatch/kernel/patch/module/module.c:23:
#include <linux/rcupdate.h>
         ^
KernelPatch/kernel/linux/include/linux/rcupdate.h:139:1: error: non-void function does not return a value in all control paths
}
^
KernelPatch/kernel/patch/module/module.c:23:10: note: in file included from KernelPatch/kernel/patch/module/module.c:23:
#include <linux/rcupdate.h>
         ^
KernelPatch/kernel/linux/include/linux/rcupdate.h:143:1: error: non-void function does not return a value in all control paths
}
^
KernelPatch/kernel/patch/module/module.c:23:10: note: in file included from KernelPatch/kernel/patch/module/module.c:23:
#include <linux/rcupdate.h>
         ^
KernelPatch/kernel/linux/include/linux/rcupdate.h:147:1: error: non-void function does not return a value in all control paths
}
^
KernelPatch/kernel/patch/module/module.c:23:10: note: in file included from KernelPatch/kernel/patch/module/module.c:23:
#include <linux/rcupdate.h>
         ^
KernelPatch/kernel/linux/include/linux/rcupdate.h:151:1: error: non-void function does not return a value in all control paths
}
^
KernelPatch/kernel/patch/module/module.c:23:10: note: in file included from KernelPatch/kernel/patch/module/module.c:23:
#include <linux/rcupdate.h>
         ^
KernelPatch/kernel/linux/include/linux/rcupdate.h:160:1: error: non-void function does not return a value in all control paths
}
^
KernelPatch/kernel/patch/module/module.c:23:10: note: in file included from KernelPatch/kernel/patch/module/module.c:23:
#include <linux/rcupdate.h>
         ^
KernelPatch/kernel/linux/include/linux/rcupdate.h:164:1: error: non-void function does not return a value in all control paths
}
^
KernelPatch/kernel/patch/module/module.c:23:10: note: in file included from KernelPatch/kernel/patch/module/module.c:23:
#include <linux/rcupdate.h>
         ^
KernelPatch/kernel/patch/module/module.c:189:13: error: expected expression
            unsigned long addr = symbol_lookup_name(name);
            ^
KernelPatch/kernel/patch/module/module.c:192:18: error: use of undeclared identifier 'addr'
            if (!addr) {
                 ^
KernelPatch/kernel/patch/module/module.c:197:31: error: use of undeclared identifier 'addr'
            sym[i].st_value = addr;
                              ^
```