### PR TITLE
kptools: Fix shift overflow warning on windows

### DIFF
--- a/tools/fls_ffs.h
+++ b/tools/fls_ffs.h
@@ -45,28 +45,28 @@ static inline uint64_t __fls(uint64_t word)
     int num = BITS_PER_LONG - 1;
 
 #if BITS_PER_LONG == 64
-    if (!(word & (~0ul << 32))) {
+    if (!(word & (~0ull << 32))) {
         num -= 32;
         word <<= 32;
     }
 #endif
-    if (!(word & (~0ul << (BITS_PER_LONG - 16)))) {
+    if (!(word & (~0ull << (BITS_PER_LONG - 16)))) {
         num -= 16;
         word <<= 16;
     }
-    if (!(word & (~0ul << (BITS_PER_LONG - 8)))) {
+    if (!(word & (~0ull << (BITS_PER_LONG - 8)))) {
         num -= 8;
         word <<= 8;
     }
-    if (!(word & (~0ul << (BITS_PER_LONG - 4)))) {
+    if (!(word & (~0ull << (BITS_PER_LONG - 4)))) {
         num -= 4;
         word <<= 4;
     }
-    if (!(word & (~0ul << (BITS_PER_LONG - 2)))) {
+    if (!(word & (~0ull << (BITS_PER_LONG - 2)))) {
         num -= 2;
         word <<= 2;
     }
-    if (!(word & (~0ul << (BITS_PER_LONG - 1)))) num -= 1;
+    if (!(word & (~0ull << (BITS_PER_LONG - 1)))) num -= 1;
     return num;
 }
 

--- a/tools/insn.c
+++ b/tools/insn.c
@@ -106,7 +106,12 @@ static inline uint64_t hweight64(u64 w)
  * position @h. For example
  * GENMASK_ULL(39, 21) gives us the 64bit vector 0x000000ffffe00000.
  */
+#ifndef _WIN32
 #define GENMASK(h, l) (((~0UL) << (l)) & (~0UL >> (BITS_PER_LONG - 1 - (h))))
+#else 
+#define GENMASK GENMASK_ULL
+#define BITS_PER_LONG_LONG 64
+#endif
 #define GENMASK_ULL(h, l) (((~0ULL) << (l)) & (~0ULL >> (BITS_PER_LONG_LONG - 1 - (h))))
 
 /*


### PR DESCRIPTION
`ul` have different size on different platform, on linux is `64bit` takes `8 bytes`, but on windows its `32bit` take `4 bytes`, suggest use `ull` force on windows platform