### PR TITLE
Fix windows lenth error

### DIFF
--- a/tools/patch.c
+++ b/tools/patch.c
@@ -376,6 +376,7 @@ int patch_update_img(const char *kimg_path, const char *kpimg_path, const char *
         extra_config_t *config = extra_configs + i;
         extra_num++;
         extra_size += sizeof(patch_extra_item_t);
+        if (!config->set_args)config->item->args_size=0;
         extra_size += config->item->args_size;
         extra_size += config->item->con_size;
         tools_logi("extra item num: %d, size: 0x%x\n", extra_num, extra_size);

--- a/tools/patch.c
+++ b/tools/patch.c
@@ -505,7 +505,7 @@ int patch_update_img(const char *kimg_path, const char *kpimg_path, const char *
         }
 
         write_file(out_path, (void *)item, sizeof(*item), true);
-        if (args_len > 0) write_file(out_path, (void *)config->set_args, args_len, true);
+        if (args_len > 0 && config->set_args) write_file(out_path, (void *)config->set_args, args_len, true);
         write_file(out_path, (void *)config->data, con_len, true);
     }
 


### PR DESCRIPTION
修复windows修补错误计算args_len,可能是未初始化内存