### PR TITLE
Fix config_flags and Optimize the output of config information in kpimg

### DIFF
--- a/kernel/include/preset.h
+++ b/kernel/include/preset.h
@@ -22,8 +22,8 @@
 #define MEMORY_RW_SIZE (2 << 20)
 #define MAP_ALIGN 0x10
 
-#define CONFIG_DEBUG 0x1
-#define CONFIG_ANDROID 0x2
+#define CONFIG_DEBUG (1 << 0)
+#define CONFIG_ANDROID (1 << 1)
 
 #define MAP_SYMBOL_NUM (5)
 #define MAP_SYMBOL_SIZE (MAP_SYMBOL_NUM * 8)

--- a/tools/patch.c
+++ b/tools/patch.c
@@ -89,7 +89,7 @@ void print_preset_info(preset_t *preset)
     fprintf(stdout, INFO_KP_IMG_SESSION "\n");
     fprintf(stdout, "version=0x%x\n", ver_num);
     fprintf(stdout, "compile_time=%s\n", header->compile_time);
-    fprintf(stdout, "config=%s,%s\n", is_debug ? "debug" : "release", is_android ? "android" : "linux");
+    fprintf(stdout, "config=%s,%s\n", is_android ? "android" : "linux", is_debug ? "debug" : "release");
     fprintf(stdout, "superkey=%s\n", setup->superkey);
 
     fprintf(stdout, INFO_ADDITIONAL_SESSION "\n");
@@ -416,7 +416,7 @@ int patch_update_img(const char *kimg_path, const char *kpimg_path, const char *
     bool is_debug = header->config_flags & CONFIG_DEBUG;
     tools_logi("kpimg version: %x\n", ver_num);
     tools_logi("kpimg compile time: %s\n", header->compile_time);
-    tools_logi("kpimg config: %s, %s\n", is_debug ? "debug" : "release", is_android ? "android" : "linux");
+    tools_logi("kpimg config: %s, %s\n", is_android ? "android" : "linux", is_debug ? "debug" : "release");
 
     setup_preset_t *setup = &preset->setup;
     memset(setup, 0, sizeof(preset->setup));

--- a/tools/patch.c
+++ b/tools/patch.c
@@ -83,8 +83,8 @@ void print_preset_info(preset_t *preset)
     setup_preset_t *setup = &preset->setup;
     version_t ver = header->kp_version;
     uint32_t ver_num = (ver.major << 16) + (ver.minor << 8) + ver.patch;
-    bool is_android = (header->config_flags | CONFIG_ANDROID) == CONFIG_ANDROID;
-    bool is_debug = (header->config_flags & CONFIG_DEBUG) == CONFIG_DEBUG;
+    bool is_android = header->config_flags & CONFIG_ANDROID;
+    bool is_debug = header->config_flags & CONFIG_DEBUG;
 
     fprintf(stdout, INFO_KP_IMG_SESSION "\n");
     fprintf(stdout, "version=0x%x\n", ver_num);
@@ -412,8 +412,8 @@ int patch_update_img(const char *kimg_path, const char *kpimg_path, const char *
     setup_header_t *header = &preset->header;
     version_t ver = header->kp_version;
     uint32_t ver_num = (ver.major << 16) + (ver.minor << 8) + ver.patch;
-    bool is_android = header->config_flags | CONFIG_ANDROID;
-    bool is_debug = header->config_flags | CONFIG_DEBUG;
+    bool is_android = header->config_flags & CONFIG_ANDROID;
+    bool is_debug = header->config_flags & CONFIG_DEBUG;
     tools_logi("kpimg version: %x\n", ver_num);
     tools_logi("kpimg compile time: %s\n", header->compile_time);
     tools_logi("kpimg config: %s, %s\n", is_debug ? "debug" : "release", is_android ? "android" : "linux");


### PR DESCRIPTION
```
[+] kpimg config: linux, release
[+] kpimg config: android, release

[kpimg]
version=0xa01
compile_time=10:37:52 Mar  6 2024
config=linux,release
superkey=
[additional]

[kpimg]
version=0xa01
compile_time=10:37:52 Mar  6 2024
config=android,release
superkey=
[additional]
```


