### PR TITLE
Fix the logic for processing the "UNCOMPRESSED_IMG" header(fix #72)

### DIFF
--- a/tools/image.c
+++ b/tools/image.c
@@ -56,16 +56,9 @@ typedef struct
 
 int32_t get_kernel_info(kernel_info_t *kinfo, const char *img, int32_t imglen)
 {
-    kinfo->img_offset = 0;
-
-    if (!strncmp("UNCOMPRESSED_IMG", img, strlen("UNCOMPRESSED_IMG"))) {
-        kinfo->img_offset = 0x14;
-        tools_logw("kernel image with UNCOMPRESSED_IMG header\n");
-    }
-
     kinfo->is_be = 0;
 
-    arm64_hdr_t *khdr = (arm64_hdr_t *)(img + kinfo->img_offset);
+    arm64_hdr_t *khdr = (arm64_hdr_t *)img;
     if (strncmp(khdr->magic, KERNEL_MAGIC, strlen(KERNEL_MAGIC))) {
         tools_loge_exit("kernel image magic error: %s\n", khdr->magic);
     }
@@ -76,10 +69,10 @@ int32_t get_kernel_info(kernel_info_t *kinfo, const char *img, int32_t imglen)
     uint32_t b_stext_insn_offset;
     if (kinfo->uefi) {
         b_primary_entry_insn = khdr->hdr.efi.b_insn;
-        b_stext_insn_offset = 4 + kinfo->img_offset;
+        b_stext_insn_offset = 4;
     } else {
         b_primary_entry_insn = khdr->hdr.nefi.b_insn;
-        b_stext_insn_offset = 0 + kinfo->img_offset;
+        b_stext_insn_offset = 0;
     }
     kinfo->b_stext_insn_offset = b_stext_insn_offset;
 
@@ -122,7 +115,7 @@ int32_t get_kernel_info(kernel_info_t *kinfo, const char *img, int32_t imglen)
 
 int32_t kernel_resize(kernel_info_t *kinfo, char *img, int32_t size)
 {
-    arm64_hdr_t *khdr = (arm64_hdr_t *)(img + kinfo->img_offset);
+    arm64_hdr_t *khdr = (arm64_hdr_t *)img;
     uint64_t ksize = size;
     if (is_be() ^ kinfo->is_be) ksize = u64swp(size);
     khdr->kernel_size_le = ksize;

--- a/tools/image.h
+++ b/tools/image.h
@@ -14,7 +14,6 @@ typedef struct
 {
     int8_t is_be; // 0: little, 1: big
     int8_t uefi; //
-    int32_t img_offset;
     int32_t load_offset;
     int32_t kernel_size;
     int32_t page_shift;

--- a/tools/kallsym.c
+++ b/tools/kallsym.c
@@ -816,13 +816,6 @@ int analyze_kallsym_info(kallsym_t *info, char *img, int32_t imglen, enum arch_t
     if (arch == ARM64) info->try_relo = 1;
     if (is_64) info->asm_PTR_size = 8;
 
-    info->img_offset = 0;
-    if (!strncmp("UNCOMPRESSED_IMG", img, strlen("UNCOMPRESSED_IMG"))) {
-        info->img_offset = 0x14;
-    }
-    img += info->img_offset;
-    imglen -= info->img_offset;
-
     int rc = -1;
     static int32_t (*base_funcs[])(kallsym_t *, char *, int32_t) = {
         find_linux_banner,
@@ -856,8 +849,6 @@ out:
 
 int32_t get_symbol_index_offset(kallsym_t *info, char *img, int32_t index)
 {
-    img = img + info->img_offset;
-
     int32_t elem_size;
     int32_t pos;
     if (info->has_relative_base) {
@@ -874,8 +865,6 @@ int32_t get_symbol_index_offset(kallsym_t *info, char *img, int32_t index)
 
 int get_symbol_offset_and_size(kallsym_t *info, char *img, char *symbol, int32_t *size)
 {
-    img = img + info->img_offset;
-
     char decomp[KSYM_SYMBOL_LEN] = { '\0' };
     char type = 0;
     *size = 0;
@@ -904,8 +893,6 @@ int get_symbol_offset_and_size(kallsym_t *info, char *img, char *symbol, int32_t
 
 int get_symbol_offset(kallsym_t *info, char *img, char *symbol)
 {
-    img = img + info->img_offset;
-
     char decomp[KSYM_SYMBOL_LEN] = { '\0' };
     char type = 0;
     char **tokens = info->kallsyms_token_table;
@@ -925,8 +912,6 @@ int get_symbol_offset(kallsym_t *info, char *img, char *symbol)
 
 int dump_all_symbols(kallsym_t *info, char *img)
 {
-    img = img + info->img_offset;
-
     char symbol[KSYM_SYMBOL_LEN] = { '\0' };
     char type = 0;
     char **tokens = info->kallsyms_token_table;
@@ -943,8 +928,6 @@ int dump_all_symbols(kallsym_t *info, char *img)
 int on_each_symbol(kallsym_t *info, char *img, void *userdata,
                    int32_t (*fn)(int32_t index, char type, const char *symbol, int32_t offset, void *userdata))
 {
-    img = img + info->img_offset;
-
     char symbol[KSYM_SYMBOL_LEN] = { '\0' };
     char type = 0;
     char **tokens = info->kallsyms_token_table;

--- a/tools/kallsym.h
+++ b/tools/kallsym.h
@@ -63,8 +63,6 @@ typedef struct
     int32_t is_64;
     int32_t is_be;
 
-    int32_t img_offset;
-
     struct
     {
         uint8_t _;

--- a/tools/patch.c
+++ b/tools/patch.c
@@ -570,14 +570,14 @@ int patch_update_img(const char *kimg_path, const char *kpimg_path, const char *
             item->args_size = i32swp(item->args_size);
         }
 
-        extra_append(out_kernel_file.kimg, item, sizeof(*item), &current_offset);
-        if (args_len > 0) extra_append(out_kernel_file.kimg, config->set_args, args_len, &current_offset);
+        extra_append(out_kernel_file.kimg, (void *)item, sizeof(*item), &current_offset);
+        if (args_len > 0) extra_append(out_kernel_file.kimg, (void *)config->set_args, args_len, &current_offset);
         extra_append(out_kernel_file.kimg, (void *)config->data, con_len, &current_offset);
     }
 
     // guard extra
     patch_extra_item_t empty_item = { 0 };
-    extra_append(out_kernel_file.kimg, &empty_item, sizeof(empty_item), &current_offset);
+    extra_append(out_kernel_file.kimg, (void *)&empty_item, sizeof(empty_item), &current_offset);
 
     write_kernel_file(&out_kernel_file, out_path);
 

--- a/tools/patch.h
+++ b/tools/patch.h
@@ -50,6 +50,20 @@ typedef struct
     patch_extra_item_t *item;
 } extra_config_t;
 
+typedef struct
+{
+    char *kfile, *kimg;
+    int kfile_len, kimg_len;
+    bool is_uncompressed_img;
+} kernel_file_t;
+
+void read_kernel_file(const char *path, kernel_file_t *kernel_file);
+void new_kernel_file(kernel_file_t *kernel_file, kernel_file_t *old, int kimg_len, bool is_different_endian);
+void append_kernel_file(kernel_file_t *kernel_file, const void *data, int len);
+void update_kernel_file_img_len(kernel_file_t *kernel_file, int kimg_len, bool is_different_endian);
+void write_kernel_file(kernel_file_t *kernel_file, const char *path);
+void free_kernel_file(kernel_file_t *kernel_file);
+
 preset_t *get_preset(const char *kimg, int kimg_len);
 
 uint32_t get_kpimg_version(const char *kpimg_path);

--- a/tools/patch.h
+++ b/tools/patch.h
@@ -59,7 +59,6 @@ typedef struct
 
 void read_kernel_file(const char *path, kernel_file_t *kernel_file);
 void new_kernel_file(kernel_file_t *kernel_file, kernel_file_t *old, int kimg_len, bool is_different_endian);
-void append_kernel_file(kernel_file_t *kernel_file, const void *data, int len);
 void update_kernel_file_img_len(kernel_file_t *kernel_file, int kimg_len, bool is_different_endian);
 void write_kernel_file(kernel_file_t *kernel_file, const char *path);
 void free_kernel_file(kernel_file_t *kernel_file);


### PR DESCRIPTION
Fix the logic for process the "UNCOMPRESSED_IMG" header(fix #72).

Just drop all internal logic to process it, and add processing logic closest to read/write file.

修复了对 UNCOMPRESSED_IMG 头的处理逻辑。

删掉了所有对这个头的内部处理逻辑，改为最外层来处理这个，避免错漏。