### PR TITLE
Fix sumgr can't grant

### DIFF
--- a/user/supercall.h
+++ b/user/supercall.h
@@ -188,7 +188,7 @@ static inline long __sc_test(const char *key, long a1, long a2, long a3)
 static inline long sc_su_grant_uid(const char *key, uid_t uid, struct su_profile *profile)
 {
     if (!key || !key[0]) return -EINVAL;
-    long ret = syscall(__NR_supercall, key, compact_cmd(key, SUPERCALL_SU_GRANT_UID), uid, profile);
+    long ret = syscall(__NR_supercall, key, compact_cmd(key, SUPERCALL_SU_GRANT_UID), profile);
     return ret;
 }
 

--- a/user/supercall_ge0a04.h
+++ b/user/supercall_ge0a04.h
@@ -171,7 +171,7 @@ static inline long __sc_test(const char *key, long a1, long a2, long a3)
 static inline long sc_su_grant_uid(const char *key, uid_t uid, struct su_profile *profile)
 {
     if (!key || !key[0]) return -EINVAL;
-    long ret = syscall(__NR_supercall, key, ver_and_cmd(key, SUPERCALL_SU_GRANT_UID), uid, profile);
+    long ret = syscall(__NR_supercall, key, ver_and_cmd(key, SUPERCALL_SU_GRANT_UID), profile);
     return ret;
 }
 


### PR DESCRIPTION
I found that APatch App grants su permissions normally, but sumgr cannot. I compared the calls to supercall and found that there is an extra uid in the parameter, but the app does not have it.
https://github.com/bmax121/KernelPatch/blob/91df9a771b3dad1ef44b4f8401cb461ee7899ac3/user/supercall.h#L191
https://github.com/bmax121/APatch/blob/0853f000186666ad617baff92f09af462397b5a6/app/src/main/cpp/supercall.h#L151
