### PR TITLE
patch: Add kernel config detect

### DIFF
--- a/tools/CMakeLists.txt
+++ b/tools/CMakeLists.txt
@@ -20,3 +20,9 @@ add_executable(
 	kptools 
 	${SOURCES}
 )
+
+find_package(ZLIB REQUIRED)
+
+target_link_libraries(kptools PRIVATE ${ZLIB_LIBRARIES})
+
+target_include_directories(kptools PRIVATE ${ZLIB_INCLUDE_DIRS})

--- a/tools/Makefile
+++ b/tools/Makefile
@@ -1,6 +1,8 @@
 
 CFLAGS = -std=c11 -Wall -Wextra -Wno-unused -Wno-unused-parameter
 
+LDFLAGS = -lz
+
 ifdef DEBUG
 	CFLAGS += -DDEBUG -g
 endif
@@ -13,7 +15,7 @@ all: kptools
 
 .PHONY: kptools
 kptools: ${objs}
-	${CC} -o $@ $^
+	${CC} -o $@ $^ $(LDFLAGS)
 
 %.o : %.c
 	$(CC) -c $(CFLAGS) $(CPPFLAGS) $< -o $@


### PR DESCRIPTION
According to the APatch documentation, CONFIG_KALLSYMS MUST be Enabled in the kernel configuration. However, some devices do not have this feature enabled in their kernels, which will cause patch errors and waste a lot of unnecessary time from developers to answering questions for users.

This commit added kernel configuration detection into KernelPatch to detect kernel configuration and intercept it in the early stage of patching to reduce the workload of answering questions.

Test: Build - Patch kernel - Detected disable - Abort
![Screenshot_2024-11-05-08-23-17-80_84d3000e3f4017145260f7618db1d683](https://github.com/user-attachments/assets/7c45c670-4d93-4713-b3b5-28dde6c12280)
