### PR TITLE
fix:#148

### DIFF
--- a/tools/kallsym.c
+++ b/tools/kallsym.c
@@ -41,8 +41,11 @@ static int find_linux_banner(kallsym_t *info, char *img, int32_t imglen)
             info->linux_banner_offset[info->banner_num++] = (int32_t)(banner - img);
             tools_logi("linux_banner %d: %s", info->banner_num, banner);
             tools_logi("linux_banner offset: 0x%lx\n", banner - img);
+            break; 
         }
     }
+    //check banner_num
+    if(info->banner_num <=0)tools_loge_exit("not found bannber");
     banner = img + info->linux_banner_offset[info->banner_num - 1];
 
     char *uts_release_start = banner + prefix_len;


### PR DESCRIPTION
我对这个boot.img解包提取的kernel进行patch分析，发现在读取banner时出现了segmentfault：
在kallsym.c的函数`find_linux_banner`中读取banner的时候出现内存非法访问了，如下是调试中的日志

第一次出现完整的banner
```sh
rocess 23738 stopped
* thread #1, name = 'kptools', stop reason = step over
    frame #0: 0x000000555555ddc0 kptools`find_linux_banner(info=0x0000007fffffeed8, img="", imglen=39755792) at kallsym.c:42:13
Target 0: (kptools) stopped.
(lldb) n
[+] linux_banner 1: Linux version 4.19.157-perf+ (root@e9898debe832) (Android (10087095, +pgo, +bolt, +lto, -mlgo, based on r487747c) clang version 17.0.2 (https://android.googlesource.com/toolchain/llvm-project d9f89f4d16663d5012e5c09495f3b30ece3d2362), LLD 17.0.2) #1 SMP PREEMPT Mon Dec 2 23:38:24 UTC 2024
Process 23738 stopped
* thread #1, name = 'kptools', stop reason = step over
    frame #0: 0x000000555555ddfc kptools`find_linux_banner(info=0x0000007fffffeed8, img="", imglen=39755792) at kallsym.c:43:13
Target 0: (kptools) stopped.
(lldb) n
[+] linux_banner offset: 0x1580018
```
在找到了banner之后，程序继续并没结束查找，继续往下
第二次继续查找
```sh
Process 23738 stopped
* thread #1, name = 'kptools', stop reason = step over
    frame #0: 0x000000555555de38 kptools`find_linux_banner(info=0x0000007fffffeed8, img="", imglen=39755792) at kallsym.c:44:9
Target 0: (kptools) stopped.
(lldb) n
Process 23738 stopped
* thread #1, name = 'kptools', stop reason = step over
    frame #0: 0x000000555555de3c kptools`find_linux_banner(info=0x0000007fffffeed8, img="", imglen=39755792) at kallsym.c:39:5
Target 0: (kptools) stopped.
(lldb) n
Process 23738 stopped
* thread #1, name = 'kptools', stop reason = step over
    frame #0: 0x000000555555dd68 kptools`find_linux_banner(info=0x0000007fffffeed8, img="", imglen=39755792) at kallsym.c:40:23
Target 0: (kptools) stopped.
(lldb) p banner
(char *) $1 = 0xb400007d29070d03 "Linux version %s (%s)"
(lldb) n
```
`isdigit`检查不满足，继续下一次循环，此时触发内存错误
```sh
(char *) $1 = 0xb400007d29070d03 "Linux version %s (%s)"
(lldb) n
Process 23738 stopped
* thread #1, name = 'kptools', stop reason = step over
    frame #0: 0x000000555555de3c kptools`find_linux_banner(info=0x0000007fffffeed8, img="", imglen=39755792) at kallsym.c:39:5
Target 0: (kptools) stopped.
(lldb) n
Process 23738 stopped
* thread #1, name = 'kptools', stop reason = signal SIGSEGV: address access protected (fault address: 0x7d29807000)
    frame #0: 0x0000007fbc008298 libc.so`twoway_memmem + 468
libc.so`twoway_memmem:
->  0x7fbc008298 <+468>: ldrb   w14, [x19, x9]
    0x7fbc00829c <+472>: lsr    x15, x14, #3
    0x7fbc0082a0 <+476>: and    x15, x15, #0x18
    0x7fbc0082a4 <+480>: ldr    x15, [x11, x15]
Target 0: (kptools) stopped.
```

这里可以修改为程序在第一次查找到满足的banner之后就可以停止了,同时也可以检查一下info->banner_num的值
如下是修改后执行的patch日志
```sh
sunfish:/data/local/tmp/test_patch #  ./kptools-android -p -i ./test_patch/kernel -s abcd1234 -k ./test_patch/kpimg -K ./test_patch/kpatch -o ./test_patch/Image2
[-] /home/roler/runDebug/KernelPatch/tools/common.c:43/read_file_align(); open file ./test_patch/kernel
 - No such file or directory
2|sunfish:/data/local/tmp/test_patch # ./kp
kpatch           kpimg            kptools          kptools-android
2|sunfish:/data/local/tmp/test_patch # ./kpt
kptools          kptools-android
2|sunfish:/data/local/tmp/test_patch # ./kptools-android -p -i kernel -s abcd1234 -k kpimg -K kpatch -o Image2
[+] kernel image_size: 0x025ea010
[+] kernel uefi header: false
[+] kernel load_offset: 0x00080000
[+] kernel kernel_size: 0x02e7a000
[+] kernel page_shift: 12
[+] new kernel image ...
[+] linux_banner 1: Linux version 4.19.157-perf+ (root@e9898debe832) (Android (10087095, +pgo, +bolt, +lto, -mlgo, based on r487747c) clang version 17.0.2 (https://android.googlesource.com/toolchain/llvm-project d9f89f4d16663d5012e5c09495f3b30ece3d2362), LLD 17.0.2) #1 SMP PREEMPT Mon Dec 2 23:38:24 UTC 2024
[+] linux_banner offset: 0x1580018
[+] kernel version major: 4, minor: 19, patch: 157
[+] kallsyms_token_table offset: 0x01c72e00
[+] endian: little
[+] kallsyms_token_index offset: 0x01c73200
[+] find arm64 relocation kernel_va: 0xffffff8008080000
[+] find arm64 relocation table range: [0x020a6218, 0x02376488), count: 0x0001e01a
[+] apply 0x0001e019 relocation entries
[+] kallsyms_markers range: [0x01c71e00, 0x01c72d40), count: 0x000001e8
[+] approximate kallsyms_offsets range: [0x01a594e0, 0x01ad3414) count: 0x0001e7cd
[+] kallsyms_names offset: 0x01ad3700
[+] kallsyms_num_syms offset: 0x01ad3600, value: 0x0001e7c5
[+] names table linux_banner index: 0x0000e746
[+] linux_banner index: 0
[+] kallsyms_offsets offset: 0x01a59500
[+] layout kimg: 0x0,0x25ea010, kpimg: 0x25eb000,0x27f80, extra: 0x2612f80,0x8ee0, end: 0x261be60, start: 0x2e7a000
[+] kpimg version: a07
[+] kpimg compile time: 19:05:39 Dec 12 2024
[+] kpimg config: linux, release
[+] tcp_init_sock: type: T, offset: 0x011ab958
[+] map_start: 0x11ab960, max_size: 0x800
[+] kallsyms_lookup_name: type: T, offset: 0x0010d304
[+] printk: type: T, offset: 0x000002e4
[+] memblock_reserve: type: T, offset: 0x001f8848
[+] memblock_free: type: T, offset: 0x001f87a8
[+] memblock_mark_nomap: type: T, offset: 0x001f8b14
[?] no symbol: memblock_phys_alloc_try_nid
[+] memblock_virt_alloc_try_nid: type: T, offset: 0x01fa2c80
[+] memblock_alloc_try_nid: type: T, offset: 0x01fa2904
[+] panic: type: T, offset: 0x00000040
[+] rest_init: type: t, offset: 0x013b4430
[+] kernel_init: type: t, offset: 0x013b4514
[?] no symbol: report_cfi_failure
[?] no symbol: __cfi_slowpath_diag
[?] no symbol: __cfi_slowpath
[+] copy_process: type: t, offset: 0x0003db3c
[?] no symbol: do_execveat_common
[+] __do_execve_file: type: t, offset: 0x00229bb8
[?] no symbol: do_execve_common
[+] do_faccessat: type: T, offset: 0x0021b8ec
[+] __arm64_sys_faccessat: type: T, offset: 0x0021bb34
[?] no symbol: __arm64_sys_faccessat2
[?] no symbol: sys_faccessat2
[+] __arm64_sys_newfstatat: type: T, offset: 0x002269ec
[+] vfs_statx: type: T, offset: 0x0022677c
[?] no symbol: vfs_fstatat
[+] avc_denied: type: t, offset: 0x003f8264
[+] slow_avc_audit: type: T, offset: 0x003f72a0
[+] input_handle_event: type: t, offset: 0x00a1fbbc
[+] superkey: abcd1234
[+] paging_init: type: T, offset: 0x01f888b0
[+] embedding exec, name: kpatch, priority: 2147483647, event: , args: , size: 0x80+0x0+0x8de0
[+] patch done: Image2
```
