### PR TITLE
fix:#148

### DIFF
--- a/tools/kallsym.c
+++ b/tools/kallsym.c
@@ -63,7 +63,12 @@ static int find_linux_banner(kallsym_t *info, char *img, int32_t imglen)
             info->linux_banner_offset[info->banner_num++] = (int32_t)(banner - img);
             tools_logi("linux_banner %d: %s", info->banner_num, banner);
             tools_logi("linux_banner offset: 0x%lx\n", banner - img);
+            break;
         }
+    }
+    if(info->banner_num<=0) {
+        tools_loge("find linux_banner error\n");
+        return -1;
     }
     banner = img + info->linux_banner_offset[info->banner_num - 1];
 


### PR DESCRIPTION
我重新测试dev分支，修改后能正常patch
```sh
sunfish:/data/local/tmp/test_patch $ ./kptools_android_dev2 -p -i kernel -S abcd1234 -k kpimg -K kpatch -o Image3
kptools_android_dev2: invalid option -- K
[+] kernel image_size: 0x025ea010
[+] kernel uefi header: false
[+] kernel load_offset: 0x00080000
[+] kernel kernel_size: 0x02e7a000
[+] kernel page_shift: 12
[+] new kernel image ...
[+] linux_banner 1: Linux version 4.19.157-perf+ (root@e9898debe832) (Android (10087095, +pgo, +bolt, +lto, -mlgo, based on r487747c) clang version 17.0.2 (https://android.googlesource.com/toolchain/llvm-project d9f89f4d16663d5012e5c09495f3b30ece3d2362), LLD 17.0.2) #1 SMP PREEMPT Mon Dec 2 23:38:24 UTC 2024
[+] linux_banner offset: 0x1580018
Segmentation fault
139|sunfish:/data/local/tmp/test_patch $ chmod +x kpto
kptools                 kptools-android         kptools_android_dev     kptools_android_dev2
139|sunfish:/data/local/tmp/test_patch $ chmod +x kptools_an
kptools_android_dev     kptools_android_dev2
139|sunfish:/data/local/tmp/test_patch $ chmod +x kptools_android_dev2
sunfish:/data/local/tmp/test_patch $ ./kptools_android_dev2 -p -i kernel -S abcd1234 -k kpimg -K kpatch -o Image3
kptools_android_dev2: invalid option -- K
[+] kernel image_size: 0x025ea010
[+] kernel uefi header: false
[+] kernel load_offset: 0x00080000
[+] kernel kernel_size: 0x02e7a000
[+] kernel page_shift: 12
[+] new kernel image ...
[+] linux_banner 1: Linux version 4.19.157-perf+ (root@e9898debe832) (Android (10087095, +pgo, +bolt, +lto, -mlgo, based on r487747c) clang version 17.0.2 (https://android.googlesource.com/toolchain/llvm-project d9f89f4d16663d5012e5c09495f3b30ece3d2362), LLD 17.0.2) #1 SMP PREEMPT Mon Dec 2 23:38:24 UTC 2024
[+] linux_banner offset: 0x1580018
[+] kernel version major: 4, minor: 19, patch: 157
[+] kallsyms_token_table offset: 0x01c72e00
[+] endian: little
[+] kallsyms_token_index offset: 0x01c73200
[+] arm64 relocation kernel_va: 0xffffff8008080000
[+] arm64 relocation table range: [0x020a6218, 0x02376488), count: 0x0001e01a
[+] apply 0x0001e019 relocation entries
[+] kallsyms_markers range: [0x01c71e00, 0x01c72d40), count: 0x000001e7
[+] approximate kallsyms_offsets range: [0x01a594e0, 0x01ad3414) count: 0x0001e7cd
[+] kallsyms_names offset: 0x01ad3700
[?] can't find kallsyms_num_syms, try: 0x0001e7c3
[+] names table linux_banner index: 0x0000e746
[+] linux_banner index: 0
[+] kallsyms_offsets offset: 0x01a59500
[+] pid_vnr: type: T, offset: 0x00067e24
[+] pid_vnr verfied sp_el0, insn: 0xd5384108
[+] layout kimg: 0x0,0x25ea010, kpimg: 0x25eb000,0x27f80, extra: 0x2612f80,0x80, end: 0x2613000, start: 0x2e7a000
[+] kpimg version: a07
[+] kpimg compile time: 19:05:39 Dec 12 2024
[+] kpimg config: linux, release
[+] tcp_init_sock: type: T, offset: 0x011ab958
[+] map_start: 0x11ab960, max_size: 0x800
[+] kallsyms_lookup_name: type: T, offset: 0x0010d304
[+] printk: type: T, offset: 0x000002e4
[+] memblock_reserve: type: T, offset: 0x001f8848
[+] memblock_free: type: T, offset: 0x001f87a8
[+] memblock_mark_nomap: type: T, offset: 0x001f8b14
[?] no symbol: memblock_phys_alloc_try_nid
[+] memblock_virt_alloc_try_nid: type: T, offset: 0x01fa2c80
[+] memblock_alloc_try_nid: type: T, offset: 0x01fa2904
[+] panic: type: T, offset: 0x00000040
[+] rest_init: type: t, offset: 0x013b4430
[+] kernel_init: type: t, offset: 0x013b4514
[?] no symbol: report_cfi_failure
[?] no symbol: __cfi_slowpath_diag
[?] no symbol: __cfi_slowpath
[+] copy_process: type: t, offset: 0x0003db3c
[+] avc_denied: type: t, offset: 0x003f8264
[+] slow_avc_audit: type: T, offset: 0x003f72a0
[+] input_handle_event: type: t, offset: 0x00a1fbbc
[+] root superkey hash: e9cee71ab932fde863338d08be4de9dfe39ea049bdafb342ce659ec5450b69ae
[+] paging_init: type: T, offset: 0x01f888b0
[+] patch done: Image3
```