### PR TITLE
init: support rc replacement on Android < 12 without /system/etc/init/hw/init.rc

### DIFF
--- a/kernel/patch/android/userd.c
+++ b/kernel/patch/android/userd.c
@@ -343,7 +343,10 @@ static void after_openat(hook_fargs4_t *args, void *udata)
             (args->local.data3 == 1)
                 ? ORIGIN_RC_FILE
                 : ORIGIN_RC_FILE2;
-        compat_copy_to_user((void *)args->local.data1, origin_rc, strlen(origin_rc)+1);
+        compat_copy_to_user(
+            (void *)args->local.data1,
+            origin_rc,
+            (args->local.data3 == 2) ? sizeof(ORIGIN_RC_FILE2) : sizeof(ORIGIN_RC_FILE));
         log_boot("restore rc file: %x\n", args->local.data0);
     }
     if (args->local.data2) {


### PR DESCRIPTION
Android versions below 12 do not provide /system/etc/init/hw/init.rc.
On these devices, init still accesses legacy rc paths during early boot,
causing fixed-path replacement logic to fail.

This change allows openat rc redirection to match multiple rc paths and
apply replacement on the first hit, ensuring compatibility across
Android versions both below and above 12.

The rc file restored in after_openat now strictly corresponds to the
originally matched path, preventing cross-path corruption and ensuring
correct user-visible behavior.

No behavior change on Android 12+ devices.