### PR TITLE
Allow UID 0/root processes to use supercall w/o superkey.

### DIFF
--- a/kernel/patch/common/supercall.c
+++ b/kernel/patch/common/supercall.c
@@ -399,7 +399,7 @@ static void before(hook_fargs6_t *args, void *udata)
     } else if (!strcmp("su", key)) {
         uid_t uid = current_uid();
         if (!is_su_allow_uid(uid)) return;
-    } else {
+    } else if (current_uid() != 0) {
         return;
     }
 


### PR DESCRIPTION
This allows to communicate with KernelPatch, even without superkey (which most modules won't have) in an easy way, opening opportunity to optimization in Zygisks, for example.

(I'm also planning to make 32-bit supercall also be feasible, considering that otherwise, only 64-bit processes can access certain commands, such as SUPERCALL_KERNELPATCH_VER).
