### PR TITLE
Fix Android kpimg build blockers

### DIFF
--- a/kernel/base/map.c
+++ b/kernel/base/map.c
@@ -66,9 +66,19 @@ static void flush_icache_all(void)
     asm volatile("isb" : : : "memory");
 }
 
+static __noinline void copy_map_data(map_data_t *dst, const map_data_t *src)
+{
+    // Avoid compiler-emitted memcpy: kpimg links freestanding without libc.
+    volatile unsigned char *d = (volatile unsigned char *)dst;
+    const volatile unsigned char *s = (const volatile unsigned char *)src;
+    for (uint64_t i = 0; i < sizeof(*dst); ++i) {
+        d[i] = s[i];
+    }
+}
+
 static __noinline void mem_proc(map_data_t *data)
 {
-	*data = *get_data();
+    copy_map_data(data, get_data());
     uint64_t kernel_va = get_kva();
 
     // relocation

--- a/kernel/patch/common/supercmd.c
+++ b/kernel/patch/common/supercmd.c
@@ -16,6 +16,9 @@
 #include <linux/slab.h>
 #include <module.h>
 #include <user_event.h>
+#ifdef ANDROID
+#include <userd.h>
+#endif
 
 static char *__user supercmd_str_to_user_sp(const char *data, uintptr_t *sp)
 {


### PR DESCRIPTION
## Summary
- include `userd.h` in `kernel/patch/common/supercmd.c` for Android builds
- avoid compiler-emitted `memcpy` in `kernel/base/map.c` so freestanding `kpimg` links successfully

## Why
Two separate build blockers showed up while building Android `kpimg` from commit `ece212d25a56dc308c8b230505cb664688abf2f1`:

1. `supercmd.c` calls `load_ap_package_config()` under `#ifdef ANDROID`, but does not include the header that declares it.
2. `*data = *get_data();` in `base/map.c` can lower to an external `memcpy` call, but `kpimg` links freestanding with `-nostdlib`, so there is no libc `memcpy` available at link time.

## Validation
- built Android `kpimg` locally with:
  - `env -u DEBUG make -C kernel TARGET_COMPILE=aarch64-none-elf- ANDROID=1 clean`
  - `env -u DEBUG make -C kernel TARGET_COMPILE=aarch64-none-elf- ANDROID=1`
- result: `kernel/kpimg` and `kernel/kpimg.elf` produced successfully
