### PR TITLE
patch: trying fix side channel attack

### DIFF
--- a/kernel/base/predata.c
+++ b/kernel/base/predata.c
@@ -104,6 +104,11 @@ int on_each_extra_item(int (*callback)(const patch_extra_item_t *extra, const ch
     return rc;
 }
 
+int has_preset_superkey()
+{
+    return start_preset.superkey[0] == '\0';
+}
+
 void predata_init()
 {
     superkey = (char *)start_preset.superkey;

--- a/kernel/include/predata.h
+++ b/kernel/include/predata.h
@@ -15,6 +15,7 @@ extern setup_header_t *setup_header;
 int auth_superkey(const char *key);
 void reset_superkey(const char *key);
 void enable_auth_root_key(bool enable);
+int has_preset_superkey();
 const char *get_superkey();
 const char *get_build_time();
 uint64_t rand_next();

--- a/kernel/patch/common/sucompat.c
+++ b/kernel/patch/common/sucompat.c
@@ -190,6 +190,9 @@ KP_EXPORT_SYMBOL(su_get_path);
 
 static void handle_before_execve(char **__user u_filename_p, char **__user uargv, void *udata)
 {
+    uid_t uid = current_uid();
+    if (!is_su_allow_uid(uid)) return;
+
     char __user *ufilename = *u_filename_p;
     char filename[SU_PATH_MAX_LEN];
     int flen = compat_strncpy_from_user(filename, ufilename, sizeof(filename));

--- a/kernel/patch/common/supercall.c
+++ b/kernel/patch/common/supercall.c
@@ -270,7 +270,7 @@ static long call_kstorage_remove(int gid, long did)
     return remove_kstorage(gid, did);
 }
 
-static long supercall(int is_key_auth, long cmd, long arg1, long arg2, long arg3, long arg4)
+static long supercall(int is_authed, long cmd, long arg1, long arg2, long arg3, long arg4)
 {
     switch (cmd) {
     case SUPERCALL_HELLO:
@@ -344,7 +344,7 @@ static long supercall(int is_key_auth, long cmd, long arg1, long arg2, long arg3
         break;
     }
 
-    if (!is_key_auth) return -EPERM;
+    if (!is_authed) return -EPERM;
 
     switch (cmd) {
     case SUPERCALL_SKEY_GET:
@@ -387,39 +387,38 @@ int is_trusted_manager_uid(uid_t uid)
     return 0;
 }
 
-
-
 static void before(hook_fargs6_t *args, void *udata)
 {
-    const char *__user ukey = (const char *__user)syscall_argn(args, 0);
+    int uid = current_uid();
+    if (get_ap_mod_exclude(uid)) return;
+
+    int is_trusted_caller = 0;
+    int is_authed = 0;
+    if (has_preset_superkey()) {
+        const char *__user key_user = (const char *__user)syscall_argn(args, 0);
+        
+        char key[MAX_KEY_LEN];
+        long len = compat_strncpy_from_user(key, key_user, MAX_KEY_LEN);
+        if (len <= 0) return;
+        is_authed = !auth_superkey(key);
+        is_trusted_caller = is_authed;
+    }
+    if (is_trusted_manager_uid(uid)) {
+        is_trusted_caller = 1;
+        is_authed = 1;
+    } else if (is_su_allow_uid(uid)) {
+        is_trusted_caller = 1;
+    }
+
+    if (!is_trusted_caller) return;
+
     long ver_xx_cmd = (long)syscall_argn(args, 1);
+    long cmd = ver_xx_cmd & 0xFFFF;
+    if (cmd < SUPERCALL_HELLO || cmd > SUPERCALL_MAX) return;
 
     // todo: from 0.10.5
     // uint32_t ver = (ver_xx_cmd & 0xFFFFFFFF00000000ul) >> 32;
     // long xx = (ver_xx_cmd & 0xFFFF0000) >> 16;
-
-    long cmd = ver_xx_cmd & 0xFFFF;
-    if (cmd < SUPERCALL_HELLO || cmd > SUPERCALL_MAX) return;
-
-    char key[MAX_KEY_LEN];
-    long len = compat_strncpy_from_user(key, ukey, MAX_KEY_LEN);
-    if (len <= 0) return;
-
-    int is_key_auth = 0;
-    int is_trusted_manager = 0;
-    is_trusted_manager = is_trusted_manager_uid(current_uid());
-    if (is_trusted_manager) {
-        is_key_auth = 1;
-    }
-
-    if (!auth_superkey(key)) {
-        is_key_auth = 1;
-    } else if (!strcmp("su", key)) {
-        uid_t uid = current_uid();
-        if (!is_su_allow_uid(uid) && !is_trusted_manager) return;
-    } else {
-        if (!is_trusted_manager) return;
-    }
 
     long a1 = (long)syscall_argn(args, 2);
     long a2 = (long)syscall_argn(args, 3);
@@ -427,7 +426,7 @@ static void before(hook_fargs6_t *args, void *udata)
     long a4 = (long)syscall_argn(args, 5);
 
     args->skip_origin = 1;
-    args->ret = supercall(is_key_auth, cmd, a1, a2, a3, a4);
+    args->ret = supercall(is_authed, cmd, a1, a2, a3, a4);
 }
 
 int supercall_install()

--- a/kernel/patch/include/userd.h
+++ b/kernel/patch/include/userd.h
@@ -15,6 +15,7 @@ int refresh_trusted_manager_uid(void);
 int refresh_trusted_manager_state(void);
 
 uid_t get_trusted_manager_uid(void);
+int is_trusted_manager_uid_android(uid_t uid);
 #endif
 
 int is_trusted_manager_uid(uid_t uid);


### PR DESCRIPTION
When mark as umount, directly skip every supercall 
When kptools doesn't patch superkey, skip superkey check.
Avoid unnecessary copy user memory before auth

Before:
```log
Starting Benchmark (100 iterations each)...
-------------------------------------------------------------------------- 
__NR_supercall (128 bytes key string)    | Avg Latency:      4.281 us | Last Res: -1 
__NR_supercall (Only \0 for key string)  | Avg Latency:      0.460 us | Last Res: -1
```

After:
```log
Starting Benchmark (100 iterations each)...
--------------------------------------------------------------------------
__NR_supercall (128 bytes key string)    | Avg Latency:      0.943 us | Last Res: -1
__NR_supercall (Only \0 for key string)  | Avg Latency:      0.607 us | Last Res: -1
```

For comparison, the following is the case of a normal system without Kernel Patch
```log
Starting Benchmark (100 iterations each)...
--------------------------------------------------------------------------
__NR_supercall (128 bytes key string)    | Avg Latency:      0.792 us | Last Res: -1
__NR_supercall (Only \0 for key string)  | Avg Latency:      0.446 us | Last Res: -1
```

And for sucompat, check is su allow uid first in handle_before_execve
avoid copy_from_user trigger in untrusted apps