### PR TITLE
fix: resolve kCFI bypass symbols at runtime when preset misses them

### DIFF
--- a/kernel/patch/common/secpass.c
+++ b/kernel/patch/common/secpass.c
@@ -53,6 +53,15 @@ int bypass_kcfi()
     // 6.1.0
     // todo: Is there more elegant way?
     unsigned long report_cfi_failure_addr = patch_config->report_cfi_failure;
+    // runtime fallback: the patcher may have missed these symbols (kallsyms
+    // version mismatch / KASLR math); resolve them ourselves so the kCFI guard
+    // is never silently absent -> otherwise every kCFI mismatch on KP memory
+    // panics (random reboots on CFI-enabled kernels)
+    if (!report_cfi_failure_addr && kallsyms_lookup_name) {
+        report_cfi_failure_addr = kallsyms_lookup_name("report_cfi_failure");
+        if (report_cfi_failure_addr)
+            log_boot("report_cfi_failure resolved at runtime: %llx\n", report_cfi_failure_addr);
+    }
     if (report_cfi_failure_addr) {
         hook_err_t err = hook((void *)report_cfi_failure_addr, (void *)replace_report_cfi_failure,
                               (void **)&backup_report_cfi_failure);
@@ -68,6 +77,12 @@ int bypass_kcfi()
     if (!__cfi_slowpath_addr) {
         __cfi_slowpath_addr = patch_config->__cfi_slowpath;
     }
+    if (!__cfi_slowpath_addr && kallsyms_lookup_name) {
+        __cfi_slowpath_addr = kallsyms_lookup_name("__cfi_slowpath_diag");
+        if (!__cfi_slowpath_addr) __cfi_slowpath_addr = kallsyms_lookup_name("__cfi_slowpath");
+        if (__cfi_slowpath_addr)
+            log_boot("__cfi_slowpath_diag resolved at runtime: %llx\n", __cfi_slowpath_addr);
+    }
     if (__cfi_slowpath_addr) {
         hook_err_t err =
             hook((void *)__cfi_slowpath_addr, (void *)replace__cfi_slowpath, (void **)&backup__cfi_slowpath);
@@ -79,8 +94,9 @@ int bypass_kcfi()
     }
 
     if (!report_cfi_failure_addr && !__cfi_slowpath_addr) {
-        // not error
-        log_boot("no symbol for pass kcfi\n");
+        // not error on kernels without CFI (<= 5.4); fatal hazard on CFI kernels
+        log_boot("no symbol for pass kcfi (preset and runtime kallsyms both empty)\n");
+        log_boot("if CONFIG_CFI_CLANG is enabled (Android 13+ GKI common), every kCFI mismatch on KP memory will panic -> random reboots\n");
     }
 
 out:

--- a/tools/symbol.c
+++ b/tools/symbol.c
@@ -291,16 +291,24 @@ int fillin_patch_config(kallsym_t *kallsym, char *img_buf, int imglen, patch_con
     if (!symbol->printk) tools_loge_exit("no symbol printk");
 
     symbol->panic = get_symbol_offset_zero(kallsym, img_buf, "panic");
+    // panic exists on every kernel; without it the KP core cannot attach its
+    // bootlog dump and a patched image that misses it is almost always broken
+    if (!symbol->panic) tools_loge_exit("no symbol panic (KP core cannot hook panic, patch aborted)");
 
     symbol->rest_init = try_get_symbol_offset_zero(kallsym, img_buf, "rest_init");
     if (!symbol->rest_init) symbol->cgroup_init = try_get_symbol_offset_zero(kallsym, img_buf, "cgroup_init");
     if (!symbol->rest_init && !symbol->cgroup_init) tools_loge_exit("no symbol rest_init");
 
     symbol->kernel_init = try_get_symbol_offset_zero(kallsym, img_buf, "kernel_init");
+    if (!symbol->kernel_init) tools_logw("no symbol kernel_init (KPM event timing degraded)\n");
 
     symbol->report_cfi_failure = get_symbol_offset_zero(kallsym, img_buf, "report_cfi_failure");
     symbol->__cfi_slowpath_diag = get_symbol_offset_zero(kallsym, img_buf, "__cfi_slowpath_diag");
     symbol->__cfi_slowpath = get_symbol_offset_zero(kallsym, img_buf, "__cfi_slowpath");
+    if (!symbol->report_cfi_failure && !symbol->__cfi_slowpath_diag && !symbol->__cfi_slowpath) {
+        tools_logw("no CFI failure handler symbol (report_cfi_failure / __cfi_slowpath_diag / __cfi_slowpath)\n");
+        tools_logw("if the kernel has CONFIG_CFI_CLANG (Android 13+ GKI common), every kCFI mismatch on KP memory will panic -> random reboots; the KP core will retry resolution via kallsyms at boot\n");
+    }
 
     symbol->copy_process = try_get_symbol_offset_zero(kallsym, img_buf, "copy_process");
     if (!symbol->copy_process) symbol->cgroup_post_fork = get_symbol_offset_zero(kallsym, img_buf, "cgroup_post_fork");


### PR DESCRIPTION
## Problem

Random black-screen reboots on CFI-enabled kernels (OPPO/OnePlus/realme, Qualcomm 8-series etc.) - see APatch issues #1522, #975, #1370.

Root cause chain:

1. Android 13+ GKI kernels enable `CONFIG_CFI_CLANG` (strict, no `CFI_PERMISSIVE`): any kCFI mismatch = `panic("CFI failure")` (`kernel/cfi.c` `handle_cfi_failure`).
2. KP's inline-hook transit code calls the relocated instruction buffer through an indirect call (`kernel/base/hook.c` `origin_func()`); that call always fails kCFI and lands in `__cfi_slowpath_diag` (5.15) / `report_cfi_failure` (6.1+).
3. The only protection is `bypass_kcfi()` (`kernel/patch/common/secpass.c`) hooking those two handlers.
4. **But `bypass_kcfi()` only reads addresses pre-filled into `patch_config` by the patcher (kptools).** When kptools fails to resolve the symbols (kallsyms layout variants / KASLR math), the preset is 0 and `bypass_kcfi` silently skips (`"no symbol for pass kcfi"`) - the device keeps running with **no CFI guard** → any indirect call into a hooked function panics → `QCOM_FORCE_WDOG_BITE_ON_PANIC` reboots ~20 s later.
5. "Cannot reproduce on demand" is expected: the trigger depends on which runtime call path hits a hooked function via an indirect call.

Device confirmation:

```
adb shell ls /sys/fs/pstore/ && adb pull /sys/fs/pstore/
grep "CFI failure" dmesg-ramoops-*          # kCFI mismatch -> bypass missing
grep "no symbol for pass kcfi" ...           # bypass_kcfi skipped
```

## Changes

- **`kernel/patch/common/secpass.c`**: when the preset address is 0, resolve `report_cfi_failure` / `__cfi_slowpath_diag` / `__cfi_slowpath` via `kallsyms_lookup_name` at boot instead of silently skipping; log the consequence clearly if both preset and runtime resolution fail.
- **`tools/symbol.c`**: fail hard on missing `panic` symbol (KP core cannot hook panic; previously unchecked); warn explicitly when all CFI handler symbols are missing instead of `no symbol` warnings that leave a silently broken image.

## Test

- `kernel/patch/common/secpass.c`: `gcc -fsyntax-only` passes.
- `tools/symbol.c`: compiles cleanly on host toolchain.
- KPM guard module (separate) verified the runtime-resolved addresses are hooked correctly.