### PR TITLE
fix: make kstorage write_kstorage find+replace atomic

### DIFF
--- a/kernel/patch/common/kstorage.c
+++ b/kernel/patch/common/kstorage.c
@@ -67,9 +67,8 @@ int write_kstorage(int gid, long did, void *data, int offset, int len, bool data
     spinlock_t *lock = &kstorage_glocks[gid];
     struct kstorage *pos = 0, *old = 0;
 
-    // Do the potentially-sleeping allocation/copy before entering the RCU
-    // read-side critical section below, since vmalloc()/memdup_user() may
-    // sleep and must never be called with rcu_read_lock() held.
+    // vmalloc()/memdup_user() may sleep and must never be called with a
+    // spinlock or RCU read-side lock held, so do the allocation/copy first.
     struct kstorage *new = (struct kstorage *)vmalloc(sizeof(struct kstorage) + len);
     if (!new) {
         return -ENOMEM;
@@ -90,17 +89,18 @@ int write_kstorage(int gid, long did, void *data, int offset, int len, bool data
     }
     new->dlen = len;
 
-    rcu_read_lock();
-
-    hlist_for_each_entry_rcu(pos, bucket, hnode)
+    // find + replace/add must be atomic under the group lock: two writers
+    // racing on the same did could otherwise both find the same old node and
+    // the second hlist_replace_rcu() on an already-replaced node writes to
+    // its poisoned ->pprev (LIST_POISON2) -> kernel Oops.
+    spin_lock(lock);
+    hlist_for_each_entry(pos, bucket, hnode)
     {
         if (pos->did == did) {
             old = pos;
             break;
         }
     }
-
-    spin_lock(lock);
     if (old) { // update
         hlist_replace_rcu(&old->hnode, &new->hnode);
     } else { // add new one
@@ -108,8 +108,6 @@ int write_kstorage(int gid, long did, void *data, int offset, int len, bool data
         group_sizes[gid]++;
     }
     spin_unlock(lock);
-
-    rcu_read_unlock();
 
     if (old) {
         bool async = true;


### PR DESCRIPTION
## Problem

`write_kstorage()` had a race between finding an existing entry and replacing
it:

```c
rcu_read_lock();
hlist_for_each_entry_rcu(pos, bucket, hnode) {  // lookup OUTSIDE the lock
    if (pos->did == did) { old = pos; break; }
}
spin_lock(lock);
if (old) {
    hlist_replace_rcu(&old->hnode, &new->hnode);  // replace INSIDE the lock
}
```

Two writers racing on the same `did` could both find the same `old` node.
The first thread replaces it (`old->pprev` becomes `LIST_POISON2`); the second
thread then calls `hlist_replace_rcu()` on the already-replaced node and
`WRITE_ONCE(*old->pprev, new)` writes through the poisoned pointer
(`dead000000000122`), causing a kernel Oops.

Observed in the field: **apd** (APatch daemon) crashed with
`Unable to handle kernel paging request at virtual address dead000000000122`
(LIST_POISON2) during APatch re-authorization after a system_server soft
restart, exactly at `hlist_replace_rcu()`'s `old->pprev = LIST_POISON2`.

## Fix

Move the lookup inside the group spinlock so find + replace/add are atomic
under the same lock. `remove_kstorage()` already does its find+del under the
lock and is unaffected.

Verified: `kstorage.c` compiles cleanly (aarch64, no new warnings).