### PR TITLE
fix: propagate hotpatch failure from hook_install instead of silent fake success

### DIFF
--- a/kernel/base/hook.c
+++ b/kernel/base/hook.c
@@ -589,13 +589,21 @@ hook_err_t hook_prepare(hook_t *hook)
 }
 KP_EXPORT_SYMBOL(hook_prepare);
 
-void hook_install(hook_t *hook)
+hook_err_t hook_install(hook_t *hook)
 {
     void *addrs[TRAMPOLINE_MAX_NUM];
     for (int32_t i = 0; i < hook->tramp_insts_num; ++i) {
         addrs[i] = (uint32_t *)hook->origin_addr + i;
     }
-    hotpatch(addrs, hook->tramp_insts, hook->tramp_insts_num);
+    // never swallow hotpatch failures: a silent write failure leaves the hook
+    // (and its purpose, e.g. the kCFI guard) installed only in name, which
+    // shows up as random panics/reboots on CFI-enabled kernels
+    int rc = hotpatch(addrs, hook->tramp_insts, hook->tramp_insts_num);
+    if (rc) {
+        logkfe("hook_install hotpatch failed: %d\n", rc);
+        return -HOOK_HOTPATCH_FAIL;
+    }
+    return HOOK_NO_ERR;
 }
 KP_EXPORT_SYMBOL(hook_install);
 
@@ -605,7 +613,8 @@ void hook_uninstall(hook_t *hook)
     for (int32_t i = 0; i < hook->tramp_insts_num; ++i) {
         addrs[i] = (uint32_t *)hook->origin_addr + i;
     }
-    hotpatch(addrs, hook->origin_insts, hook->tramp_insts_num);
+    int rc = hotpatch(addrs, hook->origin_insts, hook->tramp_insts_num);
+    if (rc) logkfe("hook_uninstall hotpatch failed: %d\n", rc);
 }
 KP_EXPORT_SYMBOL(hook_uninstall);
 
@@ -627,7 +636,8 @@ hook_err_t hook(void *func, void *replace, void **backup)
           hook->origin_addr, hook->replace_addr, hook->relo_addr, (uint64_t)hook);
     err = hook_prepare(hook);
     if (err) goto out;
-    hook_install(hook);
+    err = hook_install(hook);
+    if (err) goto out;
     logkv("Hook func: %llx succsseed\n", hook->func_addr);
     return HOOK_NO_ERR;
 out:
@@ -767,7 +777,8 @@ hook_err_t hook_wrap(void *func, int32_t argno, void *before, void *after, void 
     if (err) goto err;
     err = hook_chain_add(chain, before, after, udata);
     if (err) goto err;
-    hook_chain_install(chain);
+    err = hook_chain_install(chain);
+    if (err) goto err;
     logkv("Wrap func: %llx succsseed\n", hook->func_addr);
     return HOOK_NO_ERR;
 err:

--- a/kernel/include/hook.h
+++ b/kernel/include/hook.h
@@ -20,6 +20,7 @@ typedef enum
     HOOK_BAD_RELO = 4092,
     HOOK_TRANSIT_NO_MEM = 4091,
     HOOK_CHAIN_FULL = 4090,
+    HOOK_HOTPATCH_FAIL = 4089,
 } hook_err_t;
 
 enum hook_type
@@ -244,7 +245,7 @@ int32_t branch_absolute(uint32_t *buf, uint64_t addr);
 int32_t ret_absolute(uint32_t *buf, uint64_t addr);
 
 hook_err_t hook_prepare(hook_t *hook);
-void hook_install(hook_t *hook);
+hook_err_t hook_install(hook_t *hook);
 void hook_uninstall(hook_t *hook);
 
 /**
@@ -379,9 +380,9 @@ static inline void *fp_get_origin_func(void *hook_args)
     return (void *)chain->hook.origin_fp;
 }
 
-static inline void hook_chain_install(hook_chain_t *chain)
+static inline hook_err_t hook_chain_install(hook_chain_t *chain)
 {
-    hook_install(&chain->hook);
+    return hook_install(&chain->hook);
 }
 
 static inline void hook_chain_uninstall(hook_chain_t *chain)


### PR DESCRIPTION
## Problem

`hook_install()` discarded the `hotpatch()` return value. When writing the trampoline into kernel text fails (hypervisor-protected text on Gunyah/eVM devices, unsupported page-table layout, `aarch64_insn_patch_text_nosync` unavailable), **every hook reports success while the target function entry was never modified**.

On CFI-enabled kernels (Android 13+ GKI, strict `CONFIG_CFI_CLANG`) this is critical: the kCFI guard installed by `bypass_kcfi()` "succeeds" without actually hooking `__cfi_slowpath_diag` / `report_cfi_failure`, leaving the device with **no CFI passthrough** — any kCFI mismatch panics and the device randomly black-screen reboots.

Observed on a OnePlus device (Linux 6.12.38, Gunyah hypervisor present):

```
[0.000000] KP hook panic rc: 0                 <- claims success
[0.004246] huatuo: panic@... entry NOT hooked  <- entry instruction never changed

[0.003499] KP bypass_kcfi done: 0              <- claims success
[0.004224] huatuo: report_cfi_failure@... guarded by huatuo  <- core hook actually missing
```

The only way to notice was reading back the entry instruction (done by the
huatuo_patch KPM); the core itself had no idea.

## Changes

- `kernel/base/hook.c`: `hook_install()` now checks `hotpatch()` and returns `-HOOK_HOTPATCH_FAIL` with a log; `hook()` and `hook_wrap()` propagate it; `hook_uninstall()` logs hotpatch failures too.
- `kernel/include/hook.h`: new `HOOK_HOTPATCH_FAIL` code; `hook_install()` returns `hook_err_t`; `hook_chain_install()` propagates it.

## Observability

After this change, `bypass_kcfi()` / `patch()` surface the failure in the boot log (`bypass_kcfi done: <err>`) instead of claiming a working guard, so the random-reboot root cause is visible instead of silent.