### PR TITLE
spinlock: handle missing raw-spin symbols for KP-owned locks

### DIFF
--- a/kernel/patch/common/kp_spinlock.c
+++ b/kernel/patch/common/kp_spinlock.c
@@ -1,0 +1,67 @@
+/* SPDX-License-Identifier: GPL-2.0-or-later */
+
+#include <kp_spinlock.h>
+
+#include <asm/cmpxchg.h>
+
+static inline bool kp_native_spin_irq_pair_available(void)
+{
+    return kfunc(_raw_spin_lock_irqsave) && kfunc(_raw_spin_unlock_irqrestore);
+}
+
+static inline unsigned long kp_local_irq_save(void)
+{
+    unsigned long flags;
+
+    asm volatile("mrs %0, daif\n\t"
+                 "msr daifset, #2"
+                 : "=r"(flags)
+                 :
+                 : "memory");
+    return flags;
+}
+
+static inline void kp_local_irq_restore(unsigned long flags)
+{
+    asm volatile("msr daif, %0" : : "r"(flags) : "memory");
+}
+
+static inline void kp_local_raw_spin_lock(raw_spinlock_t *lock)
+{
+    while (cmpxchg(&lock->raw_lock.counter, 0, 1) != 0) {
+        while (__atomic_load_n(&lock->raw_lock.counter, __ATOMIC_RELAXED))
+            asm volatile("yield" ::: "memory");
+    }
+}
+
+static inline void kp_local_raw_spin_unlock(raw_spinlock_t *lock)
+{
+    smp_store_release(&lock->raw_lock.counter, 0);
+}
+
+unsigned long kp_private_spin_lock(spinlock_t *lock)
+{
+    raw_spinlock_t *raw_lock = &lock->rlock;
+    unsigned long flags;
+
+    if (likely(kp_native_spin_irq_pair_available()))
+        return kfunc(_raw_spin_lock_irqsave)(raw_lock);
+
+    /* Target preempt-count layouts vary, so the local fallback masks IRQs instead. */
+    flags = kp_local_irq_save();
+    kp_local_raw_spin_lock(raw_lock);
+    return flags;
+}
+
+void kp_private_spin_unlock(spinlock_t *lock, unsigned long flags)
+{
+    raw_spinlock_t *raw_lock = &lock->rlock;
+
+    if (likely(kp_native_spin_irq_pair_available())) {
+        kfunc(_raw_spin_unlock_irqrestore)(raw_lock, flags);
+        return;
+    }
+
+    kp_local_raw_spin_unlock(raw_lock);
+    kp_local_irq_restore(flags);
+}

--- a/kernel/patch/common/kstorage.c
+++ b/kernel/patch/common/kstorage.c
@@ -3,7 +3,7 @@
 #include <linux/kernel.h>
 #include <linux/rculist.h>
 #include <linux/slab.h>
-#include <linux/spinlock.h>
+#include <kp_spinlock.h>
 #include <linux/list.h>
 #include <compiler.h>
 #include <stdbool.h>
@@ -42,13 +42,13 @@ static void reclaim_callback(struct rcu_head *rcu)
 
 int try_alloc_kstroage_group()
 {
-    spin_lock(&used_max_group_lock);
+    unsigned long flags = kp_private_spin_lock(&used_max_group_lock);
     if (used_max_group + 1 >= KSTRORAGE_MAX_GROUP_NUM) {
-        spin_unlock(&used_max_group_lock);
+        kp_private_spin_unlock(&used_max_group_lock, flags);
         return -1;
     }
     used_max_group++;
-    spin_unlock(&used_max_group_lock);
+    kp_private_spin_unlock(&used_max_group_lock, flags);
     return used_max_group;
 }
 
@@ -100,14 +100,14 @@ int write_kstorage(int gid, long did, void *data, int offset, int len, bool data
         }
     }
 
-    spin_lock(lock);
+    unsigned long flags = kp_private_spin_lock(lock);
     if (old) { // update
         hlist_replace_rcu(&old->hnode, &new->hnode);
     } else { // add new one
         hlist_add_head_rcu(&new->hnode, bucket);
         group_sizes[gid]++;
     }
-    spin_unlock(lock);
+    kp_private_spin_unlock(lock, flags);
 
     rcu_read_unlock();
 
@@ -242,13 +242,13 @@ int remove_kstorage(int gid, long did)
     spinlock_t *lock = &kstorage_glocks[gid];
     struct kstorage *pos = 0;
 
-    spin_lock(lock);
+    unsigned long flags = kp_private_spin_lock(lock);
 
     hlist_for_each_entry_rcu(pos, bucket, hnode)
     {
         if (pos->did == did) {
             hlist_del_rcu(&pos->hnode);
-            spin_unlock(lock);
+            kp_private_spin_unlock(lock, flags);
 
             group_sizes[gid]--;
 
@@ -263,7 +263,7 @@ int remove_kstorage(int gid, long did)
         }
     }
 
-    spin_unlock(lock);
+    kp_private_spin_unlock(lock, flags);
 
     return 0;
 }

--- a/kernel/patch/common/taskob.c
+++ b/kernel/patch/common/taskob.c
@@ -20,7 +20,7 @@
 #include <uapi/asm-generic/errno.h>
 #include <predata.h>
 #include <symbol.h>
-#include <linux/spinlock.h>
+#include <kp_spinlock.h>
 #include <stdarg.h>
 #include <asm/atomic.h>
 #include <baselib.h>
@@ -86,7 +86,7 @@ struct task_ext *kf_get_task_ext(const struct task_struct *task)
 static struct task_ext *task_ext_create(struct task_struct *task)
 {
     struct task_ext *ret = NULL;
-    spin_lock(&task_ext_lock);
+    unsigned long flags = kp_private_spin_lock(&task_ext_lock);
     for (int i = 0; i < TASK_EXT_SLOT_NUM; i++) {
         if (task_ext_slots[i].task == task) {
             ret = &task_ext_slots[i].ext;
@@ -103,14 +103,14 @@ static struct task_ext *task_ext_create(struct task_struct *task)
             }
         }
     }
-    spin_unlock(&task_ext_lock);
+    kp_private_spin_unlock(&task_ext_lock, flags);
     return ret;
 }
 
 static void task_ext_free(struct task_struct *task)
 {
     if (likely(!atomic_read(&task_ext_active_count))) return;
-    spin_lock(&task_ext_lock);
+    unsigned long flags = kp_private_spin_lock(&task_ext_lock);
     for (int i = 0; i < TASK_EXT_SLOT_NUM; i++) {
         if (task_ext_slots[i].task == task) {
             task_ext_slots[i].task = NULL;
@@ -118,7 +118,7 @@ static void task_ext_free(struct task_struct *task)
             break;
         }
     }
-    spin_unlock(&task_ext_lock);
+    kp_private_spin_unlock(&task_ext_lock, flags);
 }
 
 /*

--- a/kernel/patch/include/kp_spinlock.h
+++ b/kernel/patch/include/kp_spinlock.h
@@ -1,0 +1,15 @@
+/* SPDX-License-Identifier: GPL-2.0-or-later */
+#ifndef __KP_SPINLOCK_H
+#define __KP_SPINLOCK_H
+
+#include <linux/spinlock.h>
+
+/*
+ * These helpers are only for zero-initialized, KP-owned locks. The local
+ * fallback uses a 0/1 test-and-set encoding and must not be used with locks
+ * owned by the target kernel.
+ */
+unsigned long kp_private_spin_lock(spinlock_t *lock);
+void kp_private_spin_unlock(spinlock_t *lock, unsigned long flags);
+
+#endif


### PR DESCRIPTION
## Problem

KernelPatch assumes that the generic `_raw_spin_*` wrappers always exist as
callable kallsyms symbols. This is not true for kernels that inline their
spinlock wrappers.

When lookup fails, the kfunc pointer remains zero, but the existing
`spin_lock()` wrapper still calls it unconditionally. On the affected kernel,
the first `task_ext_create()` lock acquisition branches to address zero before
Android starts.

This was confirmed on Xiaomi Mi MIX 2S (`polaris`), Linux 4.9.327, with both
KernelPatch 0.13.5 and 0.13.8.

## Confirmed root cause

The tested kernel has:

```text
CONFIG_KALLSYMS=y
CONFIG_KALLSYMS_ALL=y
CONFIG_KALLSYMS_BASE_RELATIVE=y
CONFIG_SMP=y
CONFIG_PREEMPT=y
CONFIG_PREEMPT_COUNT=y
CONFIG_QUEUED_SPINLOCKS=y

CONFIG_INLINE_SPIN_LOCK=y
CONFIG_INLINE_SPIN_LOCK_BH=y
CONFIG_INLINE_SPIN_LOCK_IRQ=y
CONFIG_INLINE_SPIN_LOCK_IRQSAVE=y
CONFIG_INLINE_SPIN_UNLOCK_BH=y
CONFIG_INLINE_SPIN_UNLOCK_IRQ=y
CONFIG_INLINE_SPIN_UNLOCK_IRQRESTORE=y

# CONFIG_DEBUG_SPINLOCK is not set
CONFIG_UNINLINE_SPIN_UNLOCK is not selected
```

The extracted kallsyms table contains 137,036 symbols, but none of these:

```text
_raw_spin_lock
_raw_spin_unlock
_raw_spin_lock_irqsave
_raw_spin_unlock_irqrestore
```

Only `queued_spin_lock_slowpath` and `queued_spin_unlock_wait` are present;
they are not drop-in replacements for the generic wrappers.

## Runtime isolation

The failure was isolated with device-side single-variable builds:

- Initialization through `bypass_selinux()` boots successfully.
- Adding `task_observer()` reproduces the boot failure.
- A task-observer build containing only lock initialization and
  `prepare_init_ext(init_task)`, with task hooks unreachable, still fails.
- Lock initialization alone boots completely.
- The otherwise identical slot-only build with a local TAS fallback boots
  completely (`sys.boot_completed=1`).

This excludes KALLSYMS parsing, the rest-init trampoline, task hooks,
`copy_process`, and earlier initialization stages as necessary causes.

## Changes

- Add `kp_private_spin_lock()` / `kp_private_spin_unlock()` for
  zero-initialized, KP-owned locks only.
- Use the native `_raw_spin_lock_irqsave` /
  `_raw_spin_unlock_irqrestore` pair when both symbols resolve.
- Otherwise use a local ARM64 fallback that:
  - saves DAIF and masks IRQs;
  - acquires with a 0/1 compare/exchange loop;
  - uses `yield` while contended;
  - releases with store-release;
  - restores the original DAIF value.
- Move the task-observer and kstorage private locks to this compatibility API.

The generic `linux/spinlock.h` API is unchanged. The local 0/1 TAS fallback is
not exposed for kernel-owned ticket/qspinlock objects.

Both task-observer and kstorage are covered. Fixing only the first task slot
allocation would allow boot to progress until kstorage reaches the same missing
raw-spin path.

## Validation

The affected-device prototype used the same DAIF/TAS fallback and completed
Android boot. The complete KernelPatch 0.13.8 candidate was reported stable
during normal use:

```text
boot SHA-256:
80fac82815eedf162afb6b5babc04f9e023f425e43740a12cb056972fbaed975
```

On this kernel, the submitted private-helper refactor selects the same local
fallback backend.

The submitted commit was additionally verified with:

- ARM64 `make kpimg` using Arm GNU Toolchain 12.2;
- x86 `make x86`;
- `git diff --check`;
- object disassembly confirming:
  - the paired native irqsave/irqrestore symbol check;
  - DAIF save/mask/restore;
  - `ldxr/stxr` compare/exchange;
  - `yield` contention loop;
  - `stlr` release;
- all taskob/kstorage normal and early-return paths release through the matching
  helper.

The refactor removes the public-header `asm/atomic.h` dependency from the
prototype and introduces no new `READ_ONCE` / `WRITE_ONCE` redefinition
warnings.

## Scope

The confirmed root cause applies to the tested Polaris 4.9.327 kernel. Runtime
coverage on other PREEMPT ARM64 configurations remains to be validated.

Possibly related symptom reports: #21 and #301. Neither report contains enough
raw-spin evidence to claim the same root cause.

Related but different work:

- #292 handles missing CFI symbols through runtime resolution.
- #272 improves KALLSYMS lookup but cannot resolve a symbol that was never
  emitted.
- #293 addresses a separate kstorage replace race and is intentionally not
  included here.
